### PR TITLE
Insert nodes at the latest position by default instead of minium

### DIFF
--- a/_unittests/ut_torch_exp/test_dynamo_compile_operators.py
+++ b/_unittests/ut_torch_exp/test_dynamo_compile_operators.py
@@ -124,6 +124,7 @@ class TestOperators(ExtTestCase):
         square_loss=False,
         use_decomposition=False,
         verbose=0,
+        raise_list=None,
     ):
         if sys.platform == "win32":
             raise unittest.SkipTest("Windows not supported yet.")
@@ -156,6 +157,7 @@ class TestOperators(ExtTestCase):
             storage=storage,
             backend=impl,
             verbose=verbose,
+            raise_list=raise_list,
             **kwargs,
         )
 
@@ -998,6 +1000,7 @@ class TestOperators(ExtTestCase):
             onnx_export=inspect.currentframe().f_code.co_name,
             impl="ref",
             test_backward=False,
+            raise_list=None,  # {"_onx_scatterelements0"},
         )
 
     def test_slice_scatter_1_backward(self):

--- a/_unittests/ut_torch_exp/test_graph_pattern_optimization.py
+++ b/_unittests/ut_torch_exp/test_graph_pattern_optimization.py
@@ -41,7 +41,7 @@ class TestGraphPatternOptimization(ExtTestCase):
             optimization_options=OptimizationOptions(
                 remove_identity=False,
                 verbose=10 if __name__ == "__main__" else 0,
-                patterns=None,
+                patterns="default",
             ),
         )
         optimized = gr.to_onnx()

--- a/_unittests/ut_torch_exp/test_graph_pattern_optimization.py
+++ b/_unittests/ut_torch_exp/test_graph_pattern_optimization.py
@@ -30,7 +30,7 @@ class TestGraphPatternOptimization(ExtTestCase):
 
     @ignore_warnings(DeprecationWarning)
     def test_try_with_custom_model(self):
-        filename = "onnx_model_init_1.onnx"
+        filename = "onnx_model_1_3.onnx"
         if not os.path.exists(filename):
             raise unittest.SkipTest(f"filename={filename!r} not found")
         onx = onnx.load(filename)
@@ -41,7 +41,7 @@ class TestGraphPatternOptimization(ExtTestCase):
             optimization_options=OptimizationOptions(
                 remove_identity=False,
                 verbose=10 if __name__ == "__main__" else 0,
-                patterns="default",
+                patterns=None,
             ),
         )
         optimized = gr.to_onnx()

--- a/experimental_experiment/torch_dynamo/debug_backend.py
+++ b/experimental_experiment/torch_dynamo/debug_backend.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import numpy as np
 from onnx import ModelProto
 import torch
@@ -47,6 +47,7 @@ def onnx_debug_backend(
     providers: Optional[Tuple[str]] = None,
     raise_exc: bool = True,
     storage: Optional[Dict[str, Any]] = None,
+    raise_list: Optional[Set[str]] = None,
 ) -> Callable:
     """
     Custom backend to export torch models into onnx
@@ -67,6 +68,8 @@ def onnx_debug_backend(
     :param providers: where to run the model, by default
     :param raise_exc: raise an exception whenever something goes wrong
     :param storage: to store any interesting objects during the process
+    :param raise_list: the builder stops any time a name falls into that list,
+        this is a debbuging tool
     :return: Callable
 
     See :ref:`l-plot-onnxrt-diff` for an example.
@@ -94,6 +97,7 @@ def onnx_debug_backend(
         verbose=verbose_onnx,
         target_opset=target_opset,
         return_builder=True,
+        raise_list=raise_list,
     )
 
     if dump_prefix:

--- a/experimental_experiment/torch_exp/_aten_functions.py
+++ b/experimental_experiment/torch_exp/_aten_functions.py
@@ -1982,7 +1982,7 @@ def _aten_slice_scatter_dynamic(
     )
     indices = g.op.Expand(index_base, shape_expand, name=name)
 
-    # Step 4: final ScatterElements.
+    # Step 4: final step
     res = g.op.ScatterElements(x, indices, src, axis=dim, name=name)
     if sts:
         g.set_type(res, g.get_type(x))
@@ -2003,7 +2003,7 @@ def aten_slice_scatter(
     name: Optional[str] = None,
 ) -> T:
 
-    if g.has_shape(x):
+    if g.has_shape(x) and is_static_shape(g.get_shape(x)):
         return _aten_slice_scatter_static(
             g,
             sts,

--- a/experimental_experiment/torch_exp/graph_builder.py
+++ b/experimental_experiment/torch_exp/graph_builder.py
@@ -1695,7 +1695,7 @@ class GraphBuilder:
         else:
             ref = ExtendedReferenceEvaluator(v)
             output = ref.run(None, feeds)
-        for name, val in zip(v.input, output):
+        for name, val in zip(v.output, output):
             self.constants_computed_[name] = val
         return output, feeds
 

--- a/experimental_experiment/torch_exp/graph_builder.py
+++ b/experimental_experiment/torch_exp/graph_builder.py
@@ -529,6 +529,12 @@ class GraphBuilder:
     def get_constant(
         self, name: str, exc: bool = True, computed_value: bool = False
     ) -> Union[np.ndarray, NodeProto]:
+        """
+        The method returns the constant *name*. It is a tensor (numpy array)
+        or a NodeProto which must be evaluated.
+        If *computed_value* is True, the NodeProto is evaluated wuth the
+        ReferenceEvaluator.
+        """
         if not self.is_constant(name):
             raise ValueError(f"Result {name!r} is not a constant.")
         possible_value = self.constants_[name]

--- a/experimental_experiment/torch_exp/graph_builder_optim.py
+++ b/experimental_experiment/torch_exp/graph_builder_optim.py
@@ -107,11 +107,11 @@ class GraphBuilderPatternOptimization:
         """
         return self.builder.is_constant(name)
 
-    def get_constant(self, name: str) -> Any:
+    def get_computed_constant(self, name: str) -> Any:
         """
         Returns the value for the constant `name`.
         """
-        return self.builder.get_constant(name)
+        return self.builder.get_constant(name, computed_value=True)
 
     def get_attribute(self, node: NodeProto, att_name: str) -> AttributeProto:
         """
@@ -147,7 +147,7 @@ class GraphBuilderPatternOptimization:
         assert input_index < len(
             node.input
         ), f"Input {input_index} does not exist in node {node}."
-        return self.get_constant(node.input[input_index])
+        return self.get_computed_constant(node.input[input_index])
 
     def has_type(self, name: str) -> bool:
         """

--- a/experimental_experiment/torch_exp/graph_builder_optim.py
+++ b/experimental_experiment/torch_exp/graph_builder_optim.py
@@ -310,10 +310,11 @@ class GraphBuilderPatternOptimization:
         assert all(
             map(lambda i: i in positions, idn)
         ), f"One node in {idn} is not referenced"
-        if match.insert_at is None:
-            insert_at = min(positions[i] for i in idn)
-        else:
-            insert_at = positions[id(match.insert_at)]
+        insert_at = (
+            max(positions[i] for i in idn)
+            if match.insert_at is None
+            else positions[id(match.insert_at)]
+        )
         new_nodes = match.apply(self, *match.nodes)
         removed = [positions[i] for i in idn]
         self.builder.insert_and_remove_nodes(insert_at, new_nodes, removed)

--- a/experimental_experiment/torch_exp/onnx_export.py
+++ b/experimental_experiment/torch_exp/onnx_export.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Set, Tuple, Union
 from onnx import ModelProto
 from onnx.defs import onnx_opset_version
 from .interpreter import DynamoInterpreter
@@ -88,6 +88,7 @@ def _make_builder_interpreter(
     as_function: bool = False,
     optimization_options: Optional[OptimizationOptions] = None,
     verbose: int = 0,
+    raise_list: Optional[Set[str]] = None,
 ) -> Tuple["torch.fx.GraphModule", GraphBuilder, DynamoInterpreter]:  # noqa: F821
     """
     Exports a torch model into ONNX using
@@ -101,6 +102,8 @@ def _make_builder_interpreter(
     :param as_function: export as a ModelProto or a FunctionProto
     :param optimization_options: optimization options
     :param verbose: verbosity level
+    :param raise_list: the builder stops any time a name falls into that list,
+        this is a debbuging tool
     :return: onnx model
     """
 
@@ -139,6 +142,7 @@ def _make_builder_interpreter(
         optimization_options=optimization_options,
         args=args,
         verbose=verbose,
+        raise_list=raise_list,
     )
 
     def retrieve(
@@ -159,6 +163,7 @@ def to_onnx(
     options: Optional[OptimizationOptions] = None,
     verbose: int = 0,
     return_builder: bool = False,
+    raise_list: Optional[Set[str]] = None,
 ) -> Union[ModelProto, Tuple[ModelProto, GraphBuilder]]:
     """
     Exports a torch model into ONNX using
@@ -172,6 +177,9 @@ def to_onnx(
     :param as_function: export as a ModelProto or a FunctionProto
     :param options: optimization options
     :param verbose: verbosity level
+    :param return_builder: returns the builder as well
+    :param raise_list: the builder stops any time a name falls into that list,
+        this is a debbuging tool
     :return: onnx model
     """
     if target_opset is None:
@@ -186,6 +194,7 @@ def to_onnx(
         as_function=as_function,
         optimization_options=options,
         verbose=verbose,
+        raise_list=raise_list,
     )
 
     builder.process(graph_module, interpreter)

--- a/experimental_experiment/torch_exp/optimization_patterns.py
+++ b/experimental_experiment/torch_exp/optimization_patterns.py
@@ -177,6 +177,8 @@ class ReshapeMatMulReshapePattern(PatternOptimization):
 
         node_before_left = g.node_before(node.input[0])
         node_before_right = g.node_before(node.input[1])
+        if node_before_left is None or node_before_right is None:
+            return None
         if (
             node_before_left.op_type != "Reshape"
             or node_before_left.domain != ""

--- a/experimental_experiment/torch_exp/optimization_patterns.py
+++ b/experimental_experiment/torch_exp/optimization_patterns.py
@@ -136,7 +136,7 @@ class ExpandPattern(PatternOptimization):
         shape = g.get_shape(node.input[0])
         if not all_int(shape):
             return None
-        new_shape = tuple(g.get_constant(node.input[1]))
+        new_shape = tuple(g.get_computed_constant(node.input[1]))
         if shape != new_shape:
             return
 
@@ -188,9 +188,13 @@ class ReshapeMatMulReshapePattern(PatternOptimization):
             return None
 
         # condition on shapes
-        shape_left = tuple(int(i) for i in g.get_constant(node_before_left.input[1]))
-        shape_right = tuple(int(i) for i in g.get_constant(node_before_right.input[1]))
-        shape_final = tuple(int(i) for i in g.get_constant(next_node.input[1]))
+        shape_left = tuple(
+            int(i) for i in g.get_computed_constant(node_before_left.input[1])
+        )
+        shape_right = tuple(
+            int(i) for i in g.get_computed_constant(node_before_right.input[1])
+        )
+        shape_final = tuple(int(i) for i in g.get_computed_constant(next_node.input[1]))
         if len(shape_final) < 4:
             return None
         ndim = len(shape_final)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,6 @@ sphinx
 sphinx-gallery
 sphinx-issues
 sphinx-runpython
-transformers!=4.38.0
+transformers!=4.38.0,!=4.38.1
 tqdm
 wheel


### PR DESCRIPTION
When doing a replacement, all replaced nodes are inserted at the same position. It was the lowest one by default (lower position in the sequence of nodes) to make sure any node consuming the inputs would have it. The default is changed to the latest to make sure every new node can use the already existing results. We might have to change that.